### PR TITLE
android: Print results to stdout/stderr instead of logcat.

### DIFF
--- a/framework/delibs/debase/deDefs.c
+++ b/framework/delibs/debase/deDefs.c
@@ -131,7 +131,7 @@ void deAssertFail (const char* reason, const char* file, int line)
 	raise(SIGTRAP);
 	abort();
 #elif (DE_OS == DE_OS_ANDROID)
-	__android_log_print(ANDROID_LOG_ERROR, "delibs", "Assertion '%s' failed at %s:%d", reason, file, line);
+	fprintf(stderr, "Assertion '%s' failed at %s:%d", reason, file, line);
 	__assert(file, line, reason);
 #else
 #	error Implement assertion function on your platform.

--- a/framework/qphelper/qpDebugOut.c
+++ b/framework/qphelper/qpDebugOut.c
@@ -75,7 +75,7 @@ void qpDiev (const char* format, va_list args)
 }
 
 /* print() implementation. */
-#if (DE_OS == DE_OS_ANDROID)
+#if (0)
 
 #include <android/log.h>
 


### PR DESCRIPTION
Given that we're running from the console, output to the console too.

Change-Id: I6d37012850950957bc33d75579e03cbfa23badea